### PR TITLE
Remove meaningless feature flag

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,6 @@ let package = Package(
                 .unsafeFlags(["-Xfrontend", "-enable-actor-data-race-checks"]),
                 .enableUpcomingFeature("BareSlashRegexLiterals"),
                 .enableUpcomingFeature("ExistentialAny"),
-                .enableUpcomingFeature("ImplicitOpenExistentials"),
             ]
         )
     ]


### PR DESCRIPTION
The upcoming feature flag `ImplicitOpenExistentials` doesn't exist at least in Swift 5.9, so I deleted it from `Package.swift`.

https://github.com/apple/swift/blob/swift-5.9-DEVELOPMENT-SNAPSHOT-2023-09-14-a/include/swift/Basic/Features.def#L113-L118