### PR TITLE
chore: disable actor data race checking

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,6 @@ let package = Package(
             swiftSettings: [
                 .unsafeFlags(["-Xfrontend", "-warn-long-function-bodies=100"], .when(configuration: .debug)),
                 .unsafeFlags(["-Xfrontend", "-warn-long-expression-type-checking=100"], .when(configuration: .debug)),
-                .unsafeFlags(["-Xfrontend", "-enable-actor-data-race-checks"]),
                 // Swift 7
                 .enableUpcomingFeature("ExistentialAny"),
             ]


### PR DESCRIPTION
This flag sometimes causes a runtime crash.